### PR TITLE
Fix genoverse panel in Location/Compara_Alignments/Image view

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Location.pm
+++ b/modules/EnsEMBL/Web/Configuration/Location.pm
@@ -28,6 +28,9 @@ sub modify_tree {
   my $view = $self->get_node('View');
   $view->set_data('genoverse', 1) if $view;
 
+  my $compara_alignments_node = $self->get_node('Compara_Alignments/Image');
+  $compara_alignments_node->set_data('genoverse', 1) if $compara_alignments_node;
+
   $self->delete_node('Variation');
   $self->delete_node('Marker');
   $self->delete_node('Compara');


### PR DESCRIPTION
## Description
There is a bug on the `/Location/Compara_Alignments/Image` page, where the top panel, which is a Genoverse component, shows a never-stopping spinner, and meanwhile the javascript keeps sending one and the same request over and over:

https://github.com/EnsemblGenomes/eg-web-parasite/assets/6834224/a3dec4c8-72f9-4e7f-be26-72daf4b1b6e2

_(for steps to reproduce the bug, see https://www.ebi.ac.uk/panda/jira/browse/PARASITE-567)_

## Cause
- `/Location/Compara_Alignments/Image` page was not loading genoverse script, because [this check](https://github.com/Ensembl/public-plugins/blob/release/110/genoverse/modules/EnsEMBL/Web/Tools/DHTMLmerge.pm#L131) was failing
- As a result, `Ensembl.genoverseSupported` property remained undefined ([link](https://github.com/Ensembl/public-plugins/blob/release/110/genoverse/htdocs/components/90_GenoverseTest.js#L28))
- This caused the `GenoverseTest` module to send a request with a `genoverse=0` parameter, in response to which ensembl sent back an html of another `GenoverseTest` panel, and the cycle repeated over and over again.

## Solution
This PR fixes the first item in the Cause section above by making sure the genoverse script is included in the html when the page is loaded.

## Sandbox
http://wp-np2-1e.ebi.ac.uk:8470/Trichobilharzia_regenti_prjeb44434/Location/Compara_Alignments/Image?align=1559;db=core;g=TREG1_37360;r=CHR_1:48357826-48406663;t=TREG1_37360.1