### PR TITLE
Add cladeII to configs.

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -36,7 +36,7 @@ CladeV = Clade V
 FreeLiving = [ Rhabditophora ]
 
 [TAXON_SUB_ORDER]
-Nematoda = [ CladeI CladeC CladeIII CladeIV CladeV ]
+Nematoda = [ CladeI CladeC CladeII CladeIII CladeIV CladeV ]
 Platyhelminthes = [ Cestoda Trematoda Monogenea FreeLiving ]
 
 [SPECIES_DISPLAY_NAME_PS]


### PR DESCRIPTION

On the genome list page values in the clade column are blank for clade II species. 


[PARASITE-728](https://www.ebi.ac.uk/panda/jira/browse/PARASITE-728)